### PR TITLE
Update Website php to use requestedFloor

### DIFF
--- a/php/controller.php
+++ b/php/controller.php
@@ -5,7 +5,7 @@ if($link === false){
     die("ERROR: Could not connect. " . mysqli_connect_error());
 }
 $sql = "UPDATE elevator.elevatorNetwork SET 
-    currentFloor=$floor WHERE nodeID=1";
+    requestedFloor=$floor WHERE nodeID=1";
 if(mysqli_query($link, $sql)){
     echo "Records inserted successfully.";
 } else{


### PR DESCRIPTION
This merge request is being put into use requseted floor when the user
submits a request for the elevator to change floors from the website.
the orignal impementation used current floor so even if the elevator
didn't change floors when the website will start to display the floor
the elevator is on it could be wrong since it never gets changed by the
controller if it doesn't run.